### PR TITLE
优化 SQL 文件格式，调整表结构定义的缩进和换行 更新 Docker Compose 配置，修正上传数据卷路径并添加日志数据卷

### DIFF
--- a/docker-compose-cn.yaml
+++ b/docker-compose-cn.yaml
@@ -44,7 +44,7 @@ services:
     volumes:
       - ./logs:/app/logs
       - ./application.yaml:/resources/application.yaml
-      - upload_data:/upload
+      - upload_data:/app/upload
     depends_on:
       - redis
       - mysql

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -42,8 +42,9 @@ services:
       - PASSKEY_NAME=<PASSKEY_NAME>
       - PASSKEY_ORIGIN=<PASSKEY_ORIGIN>
     volumes:
-      - ./logs:/app/logs
+      - logs_data:/app/logs
       - ./application.yaml:/resources/application.yaml
+      - upload_data:/app/upload
     depends_on:
       - redis
       - mysql
@@ -111,3 +112,5 @@ services:
 volumes:
   mysql_data:
   redis_data:
+  upload_data:
+  logs_data:

--- a/sinan_dev.sql
+++ b/sinan_dev.sql
@@ -15,181 +15,175 @@
 */
 
 SET NAMES utf8mb4;
-SET FOREIGN_KEY_CHECKS = 0;
+SET
+FOREIGN_KEY_CHECKS = 0;
 
 -- ----------------------------
 -- Table structure for sn_bookmark
 -- ----------------------------
 DROP TABLE IF EXISTS `sn_bookmark`;
-CREATE TABLE `sn_bookmark` (
-  `id` varchar(64) NOT NULL COMMENT '书签ID',
-  `user_id` varchar(64) DEFAULT NULL COMMENT '用户ID',
-  `space_id` varchar(64) DEFAULT NULL COMMENT '空间',
-  `name` varchar(256) DEFAULT NULL COMMENT '书签名称',
-  `pinyin` varchar(512) DEFAULT NULL,
-  `abbreviation` varchar(64) DEFAULT NULL COMMENT '简写-自动生成首字母',
-  `description` varchar(256) DEFAULT NULL COMMENT '书签描述',
-  `url` varchar(1024) NOT NULL COMMENT '书签url',
-  `icon` text COMMENT '书签Icon',
-  `num` int DEFAULT NULL COMMENT '使用次数',
-  `star` tinyint(1) DEFAULT NULL,
-  `create_time` datetime DEFAULT NULL,
-  `update_time` datetime DEFAULT NULL,
-  `deleted` int DEFAULT '0',
-  PRIMARY KEY (`id`)
+CREATE TABLE `sn_bookmark`
+(
+    `id`           varchar(64)   NOT NULL COMMENT '书签ID',
+    `user_id`      varchar(64)  DEFAULT NULL COMMENT '用户ID',
+    `space_id`     varchar(64)  DEFAULT NULL COMMENT '空间',
+    `name`         varchar(256) DEFAULT NULL COMMENT '书签名称',
+    `pinyin`       varchar(512) DEFAULT NULL,
+    `abbreviation` varchar(64)  DEFAULT NULL COMMENT '简写-自动生成首字母',
+    `description`  varchar(256) DEFAULT NULL COMMENT '书签描述',
+    `url`          varchar(1024) NOT NULL COMMENT '书签url',
+    `icon`         text COMMENT '书签Icon',
+    `num`          int          DEFAULT NULL COMMENT '使用次数',
+    `star`         tinyint(1) DEFAULT NULL,
+    `create_time`  datetime     DEFAULT NULL,
+    `update_time`  datetime     DEFAULT NULL,
+    `deleted`      int          DEFAULT '0',
+    PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='书签';
 
 -- ----------------------------
 -- Table structure for sn_bookmark_ass_tag
 -- ----------------------------
 DROP TABLE IF EXISTS `sn_bookmark_ass_tag`;
-CREATE TABLE `sn_bookmark_ass_tag` (
-  `id` varchar(64) NOT NULL COMMENT '书签ID',
-  `user_id` varchar(64) NOT NULL COMMENT '用户ID',
-  `bookmark_id` varchar(64) NOT NULL COMMENT '书签ID',
-  `tag_id` varchar(64) NOT NULL COMMENT '标签ID',
-  `create_time` datetime DEFAULT NULL,
-  `update_time` datetime DEFAULT NULL,
-  `deleted` int DEFAULT '0',
-  PRIMARY KEY (`id`)
+CREATE TABLE `sn_bookmark_ass_tag`
+(
+    `id`          varchar(64) NOT NULL COMMENT '书签ID',
+    `user_id`     varchar(64) NOT NULL COMMENT '用户ID',
+    `bookmark_id` varchar(64) NOT NULL COMMENT '书签ID',
+    `tag_id`      varchar(64) NOT NULL COMMENT '标签ID',
+    `create_time` datetime DEFAULT NULL,
+    `update_time` datetime DEFAULT NULL,
+    `deleted`     int      DEFAULT '0',
+    PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='书签关联标签';
 
 -- ----------------------------
 -- Table structure for sn_pass_key
 -- ----------------------------
 DROP TABLE IF EXISTS `sn_pass_key`;
-CREATE TABLE `sn_pass_key` (
-  `id` varchar(50) NOT NULL COMMENT 'id',
-  `user_id` varchar(50) NOT NULL DEFAULT '' COMMENT 'userId',
-  `credential_id` varchar(50) NOT NULL DEFAULT '' COMMENT 'credentialId',
-  `name` varchar(50) NOT NULL DEFAULT '' COMMENT 'name',
-  `public_key` blob,
-  `aaguid` blob,
-  `signature_count` bigint NOT NULL DEFAULT '-1' COMMENT 'signatureCount',
-  `attestation_object` blob,
-  `client_data_json` blob,
-  `create_time` datetime NOT NULL DEFAULT '1000-01-01 00:00:00' COMMENT 'createTime',
-  `update_time` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'updateTime',
-  `last_used` datetime NOT NULL DEFAULT '1000-01-01 00:00:00' COMMENT 'lastUsed',
-  `deleted` int NOT NULL DEFAULT '0' COMMENT 'deleted',
-  PRIMARY KEY (`id`)
+CREATE TABLE `sn_pass_key`
+(
+    `id`            varchar(64) NOT NULL COMMENT 'id',
+    `user_id`       varchar(64) NOT NULL COMMENT '用户id',
+    `display_name`  varchar(50) NOT NULL DEFAULT '' COMMENT '展示名称',
+    `public_key`    blob COMMENT 'Passkey公钥',
+    `credential_id` blob COMMENT 'WebAuthn凭证ID',
+    `sign_count`    bigint               DEFAULT '0' COMMENT '签名计数',
+    `user_handle`   blob COMMENT '用户句柄',
+    `describe`      varchar(255)         DEFAULT NULL COMMENT '描述',
+    `create_time`   datetime    NOT NULL DEFAULT '1000-01-01 00:00:00' COMMENT 'createTime',
+    `update_time`   timestamp   NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'updateTime',
+    `last_used`     datetime    NOT NULL DEFAULT '1000-01-01 00:00:00' COMMENT 'lastUsed',
+    `deleted`       int         NOT NULL DEFAULT '0' COMMENT 'deleted',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `id` (`id`) USING BTREE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='sn_pass_key';
-
--- ----------------------------
--- Table structure for sn_pass_key_challenge
--- ----------------------------
-DROP TABLE IF EXISTS `sn_pass_key_challenge`;
-CREATE TABLE `sn_pass_key_challenge` (
-  `id` varchar(50) NOT NULL COMMENT 'id',
-  `challenge` blob COMMENT '挑战',
-  `user_id` varchar(50) NOT NULL DEFAULT '' COMMENT 'userId',
-  `email` varchar(50) NOT NULL DEFAULT '' COMMENT 'email',
-  `challenge_type` varchar(50) NOT NULL DEFAULT '' COMMENT 'challengeType',
-  `expire_time` datetime NOT NULL DEFAULT '1000-01-01 00:00:00' COMMENT 'expireTime',
-  `create_time` datetime NOT NULL DEFAULT '1000-01-01 00:00:00' COMMENT 'createTime',
-  `used` int NOT NULL DEFAULT '-1' COMMENT 'used',
-  `deleted` int DEFAULT '0',
-  PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='sn_pass_key_challenge';
 
 -- ----------------------------
 -- Table structure for sn_share_space_ass_user
 -- ----------------------------
 DROP TABLE IF EXISTS `sn_share_space_ass_user`;
-CREATE TABLE `sn_share_space_ass_user` (
-  `id` varchar(64) NOT NULL COMMENT '书签ID',
-  `user_id` varchar(64) NOT NULL COMMENT '用户ID',
-  `space_id` varchar(64) NOT NULL COMMENT '空间ID',
-  `create_time` datetime DEFAULT NULL,
-  `update_time` datetime DEFAULT NULL,
-  `deleted` int DEFAULT '0',
-  PRIMARY KEY (`id`)
+CREATE TABLE `sn_share_space_ass_user`
+(
+    `id`          varchar(64) NOT NULL COMMENT '书签ID',
+    `user_id`     varchar(64) NOT NULL COMMENT '用户ID',
+    `space_id`    varchar(64) NOT NULL COMMENT '空间ID',
+    `create_time` datetime DEFAULT NULL,
+    `update_time` datetime DEFAULT NULL,
+    `deleted`     int      DEFAULT '0',
+    PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='分享关联用户';
 
 -- ----------------------------
 -- Table structure for sn_space
 -- ----------------------------
 DROP TABLE IF EXISTS `sn_space`;
-CREATE TABLE `sn_space` (
-  `id` varchar(64) NOT NULL COMMENT '书签ID',
-  `user_id` varchar(64) DEFAULT NULL COMMENT '用户ID',
-  `name` varchar(64) DEFAULT NULL COMMENT '空间名称',
-  `pinyin` varchar(256) DEFAULT NULL COMMENT '拼音',
-  `abbreviation` varchar(64) DEFAULT NULL COMMENT '简写-自动生成首字母',
-  `icon` varchar(256) DEFAULT NULL,
-  `sort` int DEFAULT NULL COMMENT '排序',
-  `share` tinyint(1) DEFAULT '0' COMMENT '是否分享',
-  `share_key` varchar(64) DEFAULT '' COMMENT '分享密码',
-  `description` varchar(256) DEFAULT NULL COMMENT '描述',
-  `create_time` datetime DEFAULT NULL,
-  `update_time` datetime DEFAULT NULL,
-  `deleted` int DEFAULT '0',
-  PRIMARY KEY (`id`)
+CREATE TABLE `sn_space`
+(
+    `id`           varchar(64) NOT NULL COMMENT '书签ID',
+    `user_id`      varchar(64)  DEFAULT NULL COMMENT '用户ID',
+    `name`         varchar(64)  DEFAULT NULL COMMENT '空间名称',
+    `pinyin`       varchar(256) DEFAULT NULL COMMENT '拼音',
+    `abbreviation` varchar(64)  DEFAULT NULL COMMENT '简写-自动生成首字母',
+    `icon`         varchar(256) DEFAULT NULL,
+    `sort`         int          DEFAULT NULL COMMENT '排序',
+    `share`        tinyint(1) DEFAULT '0' COMMENT '是否分享',
+    `share_key`    varchar(64)  DEFAULT '' COMMENT '分享密码',
+    `description`  varchar(256) DEFAULT NULL COMMENT '描述',
+    `create_time`  datetime     DEFAULT NULL,
+    `update_time`  datetime     DEFAULT NULL,
+    `deleted`      int          DEFAULT '0',
+    PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='空间';
 
 -- ----------------------------
 -- Table structure for sn_tag
 -- ----------------------------
 DROP TABLE IF EXISTS `sn_tag`;
-CREATE TABLE `sn_tag` (
-  `id` varchar(64) NOT NULL COMMENT '书签ID',
-  `user_id` varchar(64) DEFAULT NULL COMMENT '用户ID',
-  `name` varchar(64) DEFAULT NULL COMMENT '空间名称',
-  `pinyin` varchar(256) DEFAULT NULL COMMENT '拼音',
-  `abbreviation` varchar(64) DEFAULT NULL COMMENT '简写-自动生成首字母',
-  `color` varchar(32) DEFAULT NULL COMMENT '颜色',
-  `sort` int DEFAULT '0' COMMENT '排序',
-  `description` varchar(256) DEFAULT NULL COMMENT '描述',
-  `create_time` datetime DEFAULT NULL,
-  `update_time` datetime DEFAULT NULL,
-  `deleted` int DEFAULT '0',
-  PRIMARY KEY (`id`)
+CREATE TABLE `sn_tag`
+(
+    `id`           varchar(64) NOT NULL COMMENT '书签ID',
+    `user_id`      varchar(64)  DEFAULT NULL COMMENT '用户ID',
+    `name`         varchar(64)  DEFAULT NULL COMMENT '空间名称',
+    `pinyin`       varchar(256) DEFAULT NULL COMMENT '拼音',
+    `abbreviation` varchar(64)  DEFAULT NULL COMMENT '简写-自动生成首字母',
+    `color`        varchar(32)  DEFAULT NULL COMMENT '颜色',
+    `sort`         int          DEFAULT '0' COMMENT '排序',
+    `description`  varchar(256) DEFAULT NULL COMMENT '描述',
+    `create_time`  datetime     DEFAULT NULL,
+    `update_time`  datetime     DEFAULT NULL,
+    `deleted`      int          DEFAULT '0',
+    PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='空间';
 
 -- ----------------------------
 -- Table structure for sn_user
 -- ----------------------------
 DROP TABLE IF EXISTS `sn_user`;
-CREATE TABLE `sn_user` (
-  `id` varchar(64) NOT NULL COMMENT '书签ID',
-  `name` varchar(64) DEFAULT NULL COMMENT '空间名称',
-  `avatar` varchar(256) DEFAULT NULL COMMENT '用户头像',
-  `create_time` datetime DEFAULT NULL,
-  `update_time` datetime DEFAULT NULL,
-  `deleted` int DEFAULT '0',
-  PRIMARY KEY (`id`)
+CREATE TABLE `sn_user`
+(
+    `id`          varchar(64) NOT NULL COMMENT '书签ID',
+    `name`        varchar(64)  DEFAULT NULL COMMENT '空间名称',
+    `avatar`      varchar(256) DEFAULT NULL COMMENT '用户头像',
+    `create_time` datetime     DEFAULT NULL,
+    `update_time` datetime     DEFAULT NULL,
+    `deleted`     int          DEFAULT '0',
+    PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='用户';
 
 -- ----------------------------
 -- Table structure for sn_user_credential
 -- ----------------------------
 DROP TABLE IF EXISTS `sn_user_credential`;
-CREATE TABLE `sn_user_credential` (
-  `id` varchar(64) NOT NULL COMMENT '书签ID',
-  `user_id` varchar(64) NOT NULL COMMENT '用户ID',
-  `credential_type` varchar(64) NOT NULL COMMENT '凭证类型',
-  `credential` varchar(64) NOT NULL COMMENT '凭证',
-  `params` text COMMENT '额外参数',
-  `create_time` datetime DEFAULT NULL,
-  `update_time` datetime DEFAULT NULL,
-  `deleted` int DEFAULT '0',
-  PRIMARY KEY (`id`)
+CREATE TABLE `sn_user_credential`
+(
+    `id`              varchar(64) NOT NULL COMMENT '书签ID',
+    `user_id`         varchar(64) NOT NULL COMMENT '用户ID',
+    `credential_type` varchar(64) NOT NULL COMMENT '凭证类型',
+    `credential`      varchar(64) NOT NULL COMMENT '凭证',
+    `params`          text COMMENT '额外参数',
+    `create_time`     datetime DEFAULT NULL,
+    `update_time`     datetime DEFAULT NULL,
+    `deleted`         int      DEFAULT '0',
+    PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='凭证';
 
 -- ----------------------------
 -- Table structure for sn_user_key
 -- ----------------------------
 DROP TABLE IF EXISTS `sn_user_key`;
-CREATE TABLE `sn_user_key` (
-  `id` varchar(64) NOT NULL COMMENT '书签ID',
-  `user_id` varchar(64) DEFAULT NULL COMMENT '用户ID',
-  `name` varchar(64) DEFAULT NULL,
-  `access_key` varchar(64) DEFAULT NULL COMMENT '访问密钥',
-  `description` varchar(256) DEFAULT NULL,
-  `create_time` datetime DEFAULT NULL,
-  `update_time` datetime DEFAULT NULL,
-  `deleted` int DEFAULT '0',
-  PRIMARY KEY (`id`)
+CREATE TABLE `sn_user_key`
+(
+    `id`          varchar(64) NOT NULL COMMENT '书签ID',
+    `user_id`     varchar(64)  DEFAULT NULL COMMENT '用户ID',
+    `name`        varchar(64)  DEFAULT NULL,
+    `access_key`  varchar(64)  DEFAULT NULL COMMENT '访问密钥',
+    `description` varchar(256) DEFAULT NULL,
+    `create_time` datetime     DEFAULT NULL,
+    `update_time` datetime     DEFAULT NULL,
+    `deleted`     int          DEFAULT '0',
+    PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='用户密钥';
 
-SET FOREIGN_KEY_CHECKS = 1;
+SET
+FOREIGN_KEY_CHECKS = 1;


### PR DESCRIPTION
This pull request updates Docker Compose configurations and refines the database schema in `sinan_dev.sql`. The main changes include improvements to Docker volume management for logs and uploads, as well as significant restructuring and cleanup of the SQL schema, especially for the passkey-related tables.

**Docker Compose improvements:**

* Changed log and upload data volumes to use named Docker volumes (`logs_data`, `upload_data`) instead of local folders, improving data persistence and isolation. (`[[1]](diffhunk://#diff-3fde9d1a396e140fefc7676e1bd237d67b6864552b6f45af1ebcc27bcd0bb6e9L45-R47)`, `[[2]](diffhunk://#diff-3fde9d1a396e140fefc7676e1bd237d67b6864552b6f45af1ebcc27bcd0bb6e9R115-R116)`, `[[3]](diffhunk://#diff-bb775e7f96bea4e8d3d213d539c9ba47e870364a35b997d583dcd9467ae1b429L47-R47)`)
* Updated volume mount paths for consistency across `docker-compose.yaml` and `docker-compose-cn.yaml`. (`[[1]](diffhunk://#diff-3fde9d1a396e140fefc7676e1bd237d67b6864552b6f45af1ebcc27bcd0bb6e9L45-R47)`, `[[2]](diffhunk://#diff-bb775e7f96bea4e8d3d213d539c9ba47e870364a35b997d583dcd9467ae1b429L47-R47)`)

**Database schema changes:**

* Refactored the `sn_pass_key` table: updated field names and types, added new fields (`display_name`, `user_handle`, `describe`), changed primary key definition, and removed the `sn_pass_key_challenge` table for simplification. (`[sinan_dev.sqlL61-R87](diffhunk://#diff-c9351c8d5923f4acb6272a035f8a89f1fb73010a84c531610b4350b0dfb4af75L61-R87)`)
* Reformatted all `CREATE TABLE` statements for improved readability and consistency (added line breaks and aligned parentheses). (`[[1]](diffhunk://#diff-c9351c8d5923f4acb6272a035f8a89f1fb73010a84c531610b4350b0dfb4af75L18-R26)`, `[[2]](diffhunk://#diff-c9351c8d5923f4acb6272a035f8a89f1fb73010a84c531610b4350b0dfb4af75L46-R49)`, `[[3]](diffhunk://#diff-c9351c8d5923f4acb6272a035f8a89f1fb73010a84c531610b4350b0dfb4af75L113-R102)`, `[[4]](diffhunk://#diff-c9351c8d5923f4acb6272a035f8a89f1fb73010a84c531610b4350b0dfb4af75L134-R124)`, `[[5]](diffhunk://#diff-c9351c8d5923f4acb6272a035f8a89f1fb73010a84c531610b4350b0dfb4af75L153-R144)`, `[[6]](diffhunk://#diff-c9351c8d5923f4acb6272a035f8a89f1fb73010a84c531610b4350b0dfb4af75L167-R159)`, `[[7]](diffhunk://#diff-c9351c8d5923f4acb6272a035f8a89f1fb73010a84c531610b4350b0dfb4af75L183-R176)`)
* Minor SQL style fixes, such as splitting `SET FOREIGN_KEY_CHECKS` statements onto separate lines. (`[[1]](diffhunk://#diff-c9351c8d5923f4acb6272a035f8a89f1fb73010a84c531610b4350b0dfb4af75L18-R26)`, `[[2]](diffhunk://#diff-c9351c8d5923f4acb6272a035f8a89f1fb73010a84c531610b4350b0dfb4af75L195-R189)`)